### PR TITLE
chore: Add missing Foundation import to pass Objective-C compilation

### DIFF
--- a/OpenTelemetryWrapper.xcodeproj/project.pbxproj
+++ b/OpenTelemetryWrapper.xcodeproj/project.pbxproj
@@ -30,12 +30,12 @@
 		E31B39E32C948C52003343CB /* TracerWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31B39CB2C948C51003343CB /* TracerWrapper.swift */; };
 		E31B39E42C948C52003343CB /* ResourceWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31B39CD2C948C51003343CB /* ResourceWrapper.swift */; };
 		E31B39E52C948C52003343CB /* ContextPropagatorWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = E31B39CE2C948C51003343CB /* ContextPropagatorWrapper.swift */; };
-		E31B39E62C948C9F003343CB /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E33DF41D2C92E8FE00BB11F6 /* Foundation.framework */; };
 		E341254B2C90967B00E5AC5E /* OpenTelemetryApi in Frameworks */ = {isa = PBXBuildFile; productRef = E341254A2C90967B00E5AC5E /* OpenTelemetryApi */; };
 		E341254D2C90967B00E5AC5E /* OpenTelemetryProtocolExporterHTTP in Frameworks */ = {isa = PBXBuildFile; productRef = E341254C2C90967B00E5AC5E /* OpenTelemetryProtocolExporterHTTP */; };
 		E341254F2C90967B00E5AC5E /* OpenTelemetrySdk in Frameworks */ = {isa = PBXBuildFile; productRef = E341254E2C90967B00E5AC5E /* OpenTelemetrySdk */; };
 		E34125512C90967B00E5AC5E /* ResourceExtension in Frameworks */ = {isa = PBXBuildFile; productRef = E34125502C90967B00E5AC5E /* ResourceExtension */; };
 		E34125532C90967B00E5AC5E /* StdoutExporter in Frameworks */ = {isa = PBXBuildFile; productRef = E34125522C90967B00E5AC5E /* StdoutExporter */; };
+		E3EB32612CF6219400985F89 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E3EB325C2CF5DDCD00985F89 /* Foundation.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -62,8 +62,8 @@
 		E31B39CB2C948C51003343CB /* TracerWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TracerWrapper.swift; sourceTree = "<group>"; };
 		E31B39CD2C948C51003343CB /* ResourceWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourceWrapper.swift; sourceTree = "<group>"; };
 		E31B39CE2C948C51003343CB /* ContextPropagatorWrapper.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextPropagatorWrapper.swift; sourceTree = "<group>"; };
-		E33DF41D2C92E8FE00BB11F6 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		E34125192C9082CD00E5AC5E /* OpenTelemetryWrapper.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = OpenTelemetryWrapper.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3EB325C2CF5DDCD00985F89 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.1.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -72,7 +72,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E341254F2C90967B00E5AC5E /* OpenTelemetrySdk in Frameworks */,
-				E31B39E62C948C9F003343CB /* Foundation.framework in Frameworks */,
+				E3EB32612CF6219400985F89 /* Foundation.framework in Frameworks */,
 				E34125532C90967B00E5AC5E /* StdoutExporter in Frameworks */,
 				E341254B2C90967B00E5AC5E /* OpenTelemetryApi in Frameworks */,
 				E34125512C90967B00E5AC5E /* ResourceExtension in Frameworks */,
@@ -125,7 +125,7 @@
 		E33DF41C2C92E8FD00BB11F6 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				E33DF41D2C92E8FE00BB11F6 /* Foundation.framework */,
+				E3EB325C2CF5DDCD00985F89 /* Foundation.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -283,7 +283,7 @@
 		E341251E2C9082CD00E5AC5E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
@@ -293,6 +293,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_LINK_OBJC_RUNTIME = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -353,7 +354,7 @@
 		E341251F2C9082CD00E5AC5E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
@@ -363,6 +364,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
 				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_LINK_OBJC_RUNTIME = YES;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/OpenTelemetryWrapper.xcworkspace/contents.xcworkspacedata
+++ b/OpenTelemetryWrapper.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:OpenTelemetryWrapper.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/OpenTelemetryWrapper.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/OpenTelemetryWrapper.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,150 @@
+{
+  "originHash" : "797af6e61617f1707ff3a387e05144670e34a2d53868ce50b9358d62afc8e9fb",
+  "pins" : [
+    {
+      "identity" : "grpc-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-swift.git",
+      "state" : {
+        "revision" : "8c5e99d0255c373e0330730d191a3423c57373fb",
+        "version" : "1.24.2"
+      }
+    },
+    {
+      "identity" : "opentelemetry-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/open-telemetry/opentelemetry-swift.git",
+      "state" : {
+        "revision" : "4eb75bc8f0d6449bc197637b5c6044b51ab8c4ed",
+        "version" : "1.9.2"
+      }
+    },
+    {
+      "identity" : "opentracing-objc",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/opentracing-objc",
+      "state" : {
+        "revision" : "18c1a35ca966236cee0c5a714a51a73ff33384c1",
+        "version" : "0.5.2"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "cd142fd2f64be2100422d658e7411e39489da985",
+        "version" : "1.2.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "671108c96644956dddcd89dd59c203dcdb36cec7",
+        "version" : "1.1.4"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types",
+      "state" : {
+        "revision" : "ef18d829e8b92d731ad27bb81583edd2094d1ce3",
+        "version" : "1.3.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "9cb486020ebf03bfa5b5df985387a14a98744537",
+        "version" : "1.6.1"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "e0165b53d49b413dd987526b641e05e246782685",
+        "version" : "2.5.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "914081701062b11e3bb9e21accc379822621995e",
+        "version" : "2.76.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "2e9746cfc57554f70b650b021b6ae4738abef3e6",
+        "version" : "1.24.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "eaa71bb6ae082eee5a07407b1ad0cbd8f48f9dca",
+        "version" : "1.34.1"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "c7e95421334b1068490b5d41314a50e70bab23d1",
+        "version" : "2.29.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "bbd5e63cf949b7db0c9edaf7a21e141c52afe214",
+        "version" : "1.23.0"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "ebc7251dd5b37f627c93698e4374084d98409633",
+        "version" : "1.28.2"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "c8a44d836fe7913603e246acab7c528c2e780168",
+        "version" : "1.4.0"
+      }
+    },
+    {
+      "identity" : "thrift-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/undefinedlabs/Thrift-Swift",
+      "state" : {
+        "revision" : "18ff09e6b30e589ed38f90a1af23e193b8ecef8e",
+        "version" : "1.1.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Sources/ContextPropagatorWrapper.swift
+++ b/Sources/ContextPropagatorWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 12/07/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/OpenTelemetryWrapper.swift
+++ b/Sources/OpenTelemetryWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 12/07/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/ResourceWrapper.swift
+++ b/Sources/ResourceWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 10/07/2024.
 //
 
+import Foundation
 import ResourceExtension
 import OpenTelemetryApi
 import OpenTelemetrySdk

--- a/Sources/logs/HttpLogExporterWrapper.swift
+++ b/Sources/logs/HttpLogExporterWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 13/08/2024.
 //
 
+import Foundation
 import OpenTelemetryProtocolExporterHttp
 
 /// `HttpLogExporterWrapper` is a class that wraps the `OtlpHttpLogExporter` to expose it to Objective-C code.

--- a/Sources/logs/LogProcessorWrapper.swift
+++ b/Sources/logs/LogProcessorWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 13/08/2024.
 //
 
+import Foundation
 import OpenTelemetrySdk
 
 /// `LogProcessorWrapper` is a class that wraps the `LogRecordProcessor` to expose it to Objective-C code.

--- a/Sources/logs/LoggerProviderWrapper.swift
+++ b/Sources/logs/LoggerProviderWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 13/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/logs/LoggerWrapper.swift
+++ b/Sources/logs/LoggerWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 14/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 
 /// `LoggerWrapper` is a class that wraps the `Logger` to expose it to Objective-C code.

--- a/Sources/metrics/CounterWrapper.swift
+++ b/Sources/metrics/CounterWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 20/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 
 /// A wrapper class for the `LongCounter` to expose it to Objective-C.

--- a/Sources/metrics/GaugeWrapper.swift
+++ b/Sources/metrics/GaugeWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 20/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 
 /// A wrapper class for `LongGaugeBuilder` to expose it to Objective-C.

--- a/Sources/metrics/HistogramWrapper.swift
+++ b/Sources/metrics/HistogramWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 20/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 
 /// A wrapper class for `LongHistogram` to expose it to Objective-C.

--- a/Sources/metrics/HttpMetricExporterWrapper.swift
+++ b/Sources/metrics/HttpMetricExporterWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 19/08/2024.
 //
 
+import Foundation
 import OpenTelemetryProtocolExporterHttp
 
 /// A wrapper class for the `StableOtlpHTTPMetricExporter`, exposing it to Objective-C.

--- a/Sources/metrics/MeterProviderWrapper.swift
+++ b/Sources/metrics/MeterProviderWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 20/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/metrics/MeterWrapper.swift
+++ b/Sources/metrics/MeterWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 20/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/metrics/MetricReaderWrapper.swift
+++ b/Sources/metrics/MetricReaderWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 21/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/metrics/UpDownCounterWrapper.swift
+++ b/Sources/metrics/UpDownCounterWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 21/08/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 
 /// A wrapper class for `LongUpDownCounter` to expose it to Objective-C.

--- a/Sources/traces/HttpSpanExporterWrapper.swift
+++ b/Sources/traces/HttpSpanExporterWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 11/07/2024.
 //
 
+import Foundation
 import OpenTelemetryProtocolExporterHttp
 import StdoutExporter
 

--- a/Sources/traces/SpanProcessorWrapper.swift
+++ b/Sources/traces/SpanProcessorWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 11/07/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/traces/SpanWrapper.swift
+++ b/Sources/traces/SpanWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 10/07/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/traces/StdOutSpanExporterWrapper.swift
+++ b/Sources/traces/StdOutSpanExporterWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 11/07/2024.
 //
 
+import Foundation
 import OpenTelemetryProtocolExporterHttp
 import StdoutExporter
 

--- a/Sources/traces/TracerProviderWrapper.swift
+++ b/Sources/traces/TracerProviderWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 11/07/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 import OpenTelemetrySdk
 

--- a/Sources/traces/TracerWrapper.swift
+++ b/Sources/traces/TracerWrapper.swift
@@ -5,6 +5,7 @@
 //  Created by Alexis BURGOS on 10/07/2024.
 //
 
+import Foundation
 import OpenTelemetryApi
 
 /// A wrapper class providing access to an OpenTelemetry Tracer in Objective-C.


### PR DESCRIPTION
The OpenTelemetryWrapper sources would not compile as standalone sources without the Foundation import.